### PR TITLE
Mqueue info

### DIFF
--- a/mq_v3_api.md
+++ b/mq_v3_api.md
@@ -422,6 +422,13 @@ DELETE `/queues/{queue_name}/messages`
 
 This will remove all messages from a queue.
 
+
+Request:
+
+```json
+{}
+```
+
 Response: 200 or 404
 
 ```json


### PR DESCRIPTION
has all updates from #1 + changes the way push queues are represented to match current output rather than original doc. need to decide this, the previous was easier to notice a push queue but this is current implementation. certain things like 'type' field needed to be extracted from w/i "push" anyway. 
